### PR TITLE
bug:KICS high violation fixes

### DIFF
--- a/backend/src/main/resources/static/bpn-discovery-service-openapi.yaml
+++ b/backend/src/main/resources/static/bpn-discovery-service-openapi.yaml
@@ -177,6 +177,7 @@ components:
         bpns:
           title: bpns
           type: array
+          maxItems: 10000
           items:
             $ref: '#/components/schemas/Bpn'
     Bpn:

--- a/charts/bpndiscovery/templates/deployment.yaml
+++ b/charts/bpndiscovery/templates/deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: {{ $deployment_name }}
     spec:
+      securityContext:
+        runAsUser: 100
       containers:
         - name: {{ $deployment_name }}
           image: {{ .Values.bpndiscovery.image.registry }}/{{ .Values.bpndiscovery.image.repository }}:{{ .Values.bpndiscovery.image.version | default .Chart.AppVersion }}
@@ -24,6 +26,11 @@ spec:
           {{- end }}
           ports:
             - containerPort: {{ .Values.bpndiscovery.containerPort }}
+#         Containers should not run with allowPrivilegeEscalation in order to prevent them from gaining more privileges than their parent process
+#         Refer Set the security context for a Pod section here - https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+          securityContext:
+            runAsUser: 100
+            allowPrivilegeEscalation: false
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness


### PR DESCRIPTION
## Description

This PR consists of KICS high violation fixes

Fixes

- Privilege Escalation Allowed violation fix - Containers should not run with allowPrivilegeEscalation in order to prevent them from gaining more privileges than their parent process. Please refer Refer Set the security context for a Pod section for more information [here]([ttps://kubernetes.io/docs/tasks/configure-pod-container/security-context/](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/))
- Array schema should have the field 'maxItems' set in OpenAPI yaml file