### PR TITLE
chore: make helm test possible on worklow dispatch

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -72,4 +72,4 @@ jobs:
 
       - name: Run chart-testing (install)
         run: ct install --charts charts/bpndiscovery --config charts/chart-testing-config.yaml
-        if: steps.list-changed.outputs.changed == 'true'
+        if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'


### PR DESCRIPTION
## Description

- if i want to test https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-09 need to run it on workflow dispatch 

updates #53 


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
