### PR TITLE
docs: add notice information to glossary.md

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -6,3 +6,12 @@
 | Realm    | Manages a set of users, credentials, roles. Authenticates the users it controls.                           |
 | BPN      | Business Partner Number                                                                                    |
 | EDC      | Eclipse Data Space Connector                                                                               |
+
+### NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023 Robert Bosch Manufacturing Solutions GmbH
+- SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/sldt-bpn-discovery.git


### PR DESCRIPTION

## Description
- add Legal notice for documentation (every file) 
- https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07#description

> In this TRG, by non-code artifacts we mean documentation and images embedded in this documentation. All of these artifacts have to include notices about copyright, license and source location information. Excluded are the [legal documenation files](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-01#description).

fixes #60

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
