### PR TITLE
feat(ingress): generalize Helm ingress template for any controller

### DIFF
--- a/charts/bpndiscovery/templates/ingress.yaml
+++ b/charts/bpndiscovery/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.bpndiscovery.ingress.enabled }}
+{{- if .Values.bpndiscovery.ingress.enabled -}}
 # Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
 # Copyright (c) 2023 Contributors to the Eclipse Foundation
 #
@@ -17,32 +17,67 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
-
+{{- end }}
+{{ if .Values.bpndiscovery.ingress.enabled -}}
+{{- $fullName := include "bpndiscovery.fullname" . -}}
+{{- $svcPort := .Values.bpndiscovery.service.port -}}
+{{- if and .Values.bpndiscovery.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.bpndiscovery.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.bpndiscovery.ingress.annotations "kubernetes.io/ingress.class" .Values.bpndiscovery.ingress.className }}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
-  name: {{ include "bpndiscovery.fullname" . }}
-  annotations:
-{{ .Values.bpndiscovery.ingress.annotations | toYaml | indent 4 }}
+  name: {{ $fullName }}-ingress
+  namespace: {{ .Release.Namespace }}
   labels:
-  {{- include "bpndiscovery.labels" . | nindent 4 }}
+    {{- include "bpndiscovery.labels" . | nindent 4 }}
+  {{- with .Values.bpndiscovery.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+  {{- if and .Values.bpndiscovery.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.bpndiscovery.ingress.className }}
+  {{- end }}
   {{- if .Values.bpndiscovery.ingress.tls }}
   tls:
+    {{- range .Values.bpndiscovery.ingress.tls }}
     - hosts:
-        - {{ .Values.bpndiscovery.host }}
-      secretName: bpndiscovery-certificate-secret
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
   {{- end }}
   rules:
-    - host: {{ .Values.bpndiscovery.host }}
+    {{- range .Values.bpndiscovery.ingress.hosts }}
+    - host: {{ .host | quote }}
       http:
         paths:
-          - path: {{printf "%s(/|$)(.*)" .Values.bpndiscovery.ingress.urlPrefix }}
-            pathType: Prefix
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ include "bpndiscovery.fullname" . }}
+                name: {{ $fullName }}-{{ .backend.service }}
                 port:
-                  number: {{ .Values.bpndiscovery.service.port }}
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}-{{ .backend.service }}
+              servicePort: {{ .backend.port }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
 {{- end }}
+

--- a/charts/bpndiscovery/values.yaml
+++ b/charts/bpndiscovery/values.yaml
@@ -72,11 +72,30 @@ bpndiscovery:
     user:
     password:
   ingress:
-    enabled: false
-    tls: false
-    urlPrefix: /bpndiscovery
-    className: nginx
-    annotations: {}
+      enabled: false
+      className: "nginx"
+      annotations:
+        # -- Provide TLS certificate issuer
+        # cert-manager.io/cluster-issuer: "my-issuer"
+        nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+        nginx.ingress.kubernetes.io/use-regex: "true"
+        nginx.ingress.kubernetes.io/enable-cors: "true"
+        nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+        nginx.ingress.kubernetes.io/x-forwarded-prefix: /bpndiscovery
+      tls:
+        # -- Provide tls secret.
+        - secretName: "bpndiscovery-certificate-secret"
+          # -- Provide host for tls secret.
+          hosts:
+            - "bpndiscovery.example.org"
+      hosts:
+        - host: "bpndiscovery.example.org"
+          paths:
+            - path: "/bpndiscovery(/|$)(.*)"
+              pathType: "ImplementationSpecific"
+              backend:
+                service: "bpndiscovery"
+                port: 8080
   resources:
     limits:
       cpu: 750m


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

### What does this PR introduce? 

This change enables the usage of different ingress controller besides `nginx`. 
For this the following two files were adjusted:
* `charts/bpndiscovery/templates/ingress.yaml`
* `charts/bpndiscovery/values.yaml`

As guideline, I used existing ingress templates from the tractus-x ecosystem. So, that they're following the same standards. 

### Does it fix a bug or add a new feature?

I would call it an enhancement of the existing solution. 

### Is it enhancing documentation?

Only if you take the default `values.yaml` as part of the documenation. 

### Changes
- Replaced NGINX‑specific logic with dynamic `ingressClassName` and annotations
- Add version‑aware API version, `pathType` and TLS handling
- Support arbitrary hosts, paths and backends via `.Values.bpndiscovery.ingress`
- Validated with both NGINX and Traefik examples

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
Might be related to: https://github.com/eclipse-tractusx/sldt-bpn-discovery/issues/36

### Discussion

The tractus-x ecosystem uses the license documentation syntax 
```yaml
{{- /*
* Copyright (c) 2022 Contributors to the Eclipse Foundation
*
* See the NOTICE file(s) distributed with this work for additional
* information regarding copyright ownership.
[...]
*
* SPDX-License-Identifier: Apache-2.0
*/}}
```
while this ingress file uses 
```yaml
# Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
# Copyright (c) 2023 Contributors to the Eclipse Foundation
[...]
# SPDX-License-Identifier: Apache-2.0
###############################################################
```

The difference is that the former one is just a comment and only visible in the source code, while the letter one will be visible in the source- and rendered-code. For this PR, I kept the latter version, so that it will be seen in the rendered code as well. To be fully compliant with the tractus-x coding-standard, this should be changed. But eventually, this has no impact on the functionality. 


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files


## Tests

The following shows the **rendered output of an example** from the **existing version**, compared with the rendered output from the **PR's version**

* Initial
```yaml
---
# Source: bpndiscovery/templates/ingress.yaml
# Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
# Copyright (c) 2023 Contributors to the Eclipse Foundation
#
# See the NOTICE file(s) distributed with this work for additional
# information regarding copyright ownership.
#
# This program and the accompanying materials are made available under the
# terms of the Apache License, Version 2.0 which is available at
# https://www.apache.org/licenses/LICENSE-2.0.
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
# License for the specific language governing permissions and limitations
# under the License.
#
# SPDX-License-Identifier: Apache-2.0
###############################################################

apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: bpndiscovery
  annotations:
    cert-manager.io/cluster-issuer: my-issuer
    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
    nginx.ingress.kubernetes.io/enable-cors: "true"
    nginx.ingress.kubernetes.io/rewrite-target: /$2
    nginx.ingress.kubernetes.io/use-regex: "true"
    nginx.ingress.kubernetes.io/x-forwarded-prefix: /bpndiscovery
  labels:
    helm.sh/chart: bpndiscovery-0.5.1
    app.kubernetes.io/name: bpndiscovery
    app.kubernetes.io/instance: bpndiscovery
    app.kubernetes.io/version: "0.6.1"
    app.kubernetes.io/managed-by: Helm
spec:
  ingressClassName: nginx
  tls:
    - hosts:
        - semantics.tx.test
      secretName: bpndiscovery-certificate-secret
  rules:
    - host: semantics.tx.test
      http:
        paths:
          - path: /bpndiscovery(/|$)(.*)
            pathType: Prefix
            backend:
              service:
                name: bpndiscovery
                port:
                  number: 8080
```

* new nginx ingress
```yaml
---
# Source: bpndiscovery/templates/ingress.yaml
# Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
# Copyright (c) 2023 Contributors to the Eclipse Foundation
#
# See the NOTICE file(s) distributed with this work for additional
# information regarding copyright ownership.
#
# This program and the accompanying materials are made available under the
# terms of the Apache License, Version 2.0 which is available at
# https://www.apache.org/licenses/LICENSE-2.0.
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
# License for the specific language governing permissions and limitations
# under the License.
#
# SPDX-License-Identifier: Apache-2.0
###############################################################
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: bpndiscovery-ingress
  namespace: umbrella
  annotations:
    cert-manager.io/cluster-issuer: my-issuer
    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
    nginx.ingress.kubernetes.io/enable-cors: "true"
    nginx.ingress.kubernetes.io/rewrite-target: /$2
    nginx.ingress.kubernetes.io/use-regex: "true"
    nginx.ingress.kubernetes.io/x-forwarded-prefix: /bpndiscovery
  labels:
    helm.sh/chart: bpndiscovery-0.5.1
    app.kubernetes.io/name: bpndiscovery
    app.kubernetes.io/instance: bpndiscovery
    app.kubernetes.io/version: "0.6.1"
    app.kubernetes.io/managed-by: Helm
spec:
  ingressClassName: nginx
  tls:
    - hosts:
        - "semantics.tx.test"
      secretName: bpndiscovery-certificate-secret
  rules:
    - host: "semantics.tx.test"
      http:
        paths:
          - path: /bpndiscovery(/|$)(.*)
            pathType: ImplementationSpecific
            backend:
              service:
                name: bpndiscovery-bpndiscovery
                port:
                  number: 8080
```

* now possible: traefik ingress
```yaml
---
# Source: bpndiscovery/templates/ingress.yaml
# Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
# Copyright (c) 2023 Contributors to the Eclipse Foundation
#
# See the NOTICE file(s) distributed with this work for additional
# information regarding copyright ownership.
#
# This program and the accompanying materials are made available under the
# terms of the Apache License, Version 2.0 which is available at
# https://www.apache.org/licenses/LICENSE-2.0.
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
# License for the specific language governing permissions and limitations
# under the License.
#
# SPDX-License-Identifier: Apache-2.0
###############################################################
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: bpndiscovery-ingress
  namespace: umbrella
  annotations:
    cert-manager.io/cluster-issuer: my-issuer
    traefik.ingress.kubernetes.io/router.entrypoints: websecure
    traefik.ingress.kubernetes.io/router.middlewares: my-cors-headers@kubernetescrd
    traefik.ingress.kubernetes.io/router.tls: "true"
  labels:
    helm.sh/chart: bpndiscovery-0.5.1
    app.kubernetes.io/name: bpndiscovery
    app.kubernetes.io/instance: bpndiscovery
    app.kubernetes.io/version: "0.6.1"
    app.kubernetes.io/managed-by: Helm
spec:
  ingressClassName: traefik
  tls:
    - hosts:
        - "semantics.tx.test"
      secretName: bpndiscovery-certificate-secret
  rules:
    - host: "semantics.tx.test"
      http:
        paths:
          - path: /bpndiscovery
            pathType: Prefix
            backend:
              service:
                name: bpndiscovery-bpndiscovery
                port:
                  number: 8080
```
